### PR TITLE
Add JMeter threads,duration arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,16 @@ This will start the agent at http://localhost:8000, where you can interact with 
 ### Supported Performance Testing Tools
 
 #### JMeter
-The agent can execute JMeter test plans (.jmx files) in both GUI and non-GUI modes.
+The agent can execute JMeter test plans (.jmx files) in both GUI and non-GUI modes with customizable duration and virtual user count.
 
 **Example commands:**
 - Run in non-GUI mode (default):
   ```
   Run my JMeter test at /path/to/test.jmx
+  ```
+- Run in non-GUI mode (with custom settings):
+  ```
+  Run my JMeter test at /path/to/test.jmx with 20 users and 300 seconds
   ```
 - Run in GUI mode:
   ```

--- a/multi_tool_agent/agent.py
+++ b/multi_tool_agent/agent.py
@@ -19,14 +19,16 @@ logger = logging.getLogger(__name__)
 # Load environment variables
 load_dotenv()
 
-async def execute_jmeter_test(test_file: str, gui_mode: bool = False) -> str:
+async def execute_jmeter_test(test_file: str, duration: int = 30, threads: int = 10, gui_mode: bool = False) -> str:
     """Execute a JMeter test.
 
     Args:
         test_file: Path to the JMeter test file (.jmx)
+        duration: Duration of the test in seconds (e.g., 30, 60)
+        threads: Number of virtual users to simulate
         gui_mode: Whether to run in GUI mode (default: False)
     """
-    return await run_jmeter(test_file, non_gui=not gui_mode)  # Run in non-GUI mode by default
+    return await run_jmeter(test_file, duration, threads, non_gui=not gui_mode) # Run in non-GUI mode by default
 
 async def execute_jmeter_test_non_gui(test_file: str) -> str:
     """Execute a JMeter test in non-GUI mode.

--- a/multi_tool_agent/agent.py
+++ b/multi_tool_agent/agent.py
@@ -30,13 +30,13 @@ async def execute_jmeter_test(test_file: str, duration: int = 30, threads: int =
     """
     return await run_jmeter(test_file, duration, threads, non_gui=not gui_mode) # Run in non-GUI mode by default
 
-async def execute_jmeter_test_non_gui(test_file: str) -> str:
+async def execute_jmeter_test_non_gui(test_file: str, duration: int = 30, threads: int = 10) -> str:
     """Execute a JMeter test in non-GUI mode.
 
     Args:
         test_file: Path to the JMeter test file (.jmx)
     """
-    return await run_jmeter(test_file, non_gui=True)
+    return await run_jmeter(test_file, duration , threads, non_gui=True)
 
 async def execute_k6_test(script_file: str, duration: str = "30s", vus: int = 10) -> str:
     """Execute a k6 load test.

--- a/multi_tool_agent/jmeter_utils.py
+++ b/multi_tool_agent/jmeter_utils.py
@@ -14,11 +14,13 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-async def run_jmeter(test_file: str, non_gui: bool = True) -> str:
+async def run_jmeter(test_file: str, duration: int = 30, threads: int = 10, non_gui: bool = True) -> str:
     """Run a JMeter test.
 
     Args:
         test_file: Path to the JMeter test file (.jmx)
+        duration: Duration of the test in seconds (e.g., 30, 60)
+        threads: Number of virtual users to simulate
         non_gui: Run in non-GUI mode (default: True)
 
     Returns:
@@ -53,6 +55,8 @@ async def run_jmeter(test_file: str, non_gui: bool = True) -> str:
         if non_gui:
             cmd.extend(['-n'])
         cmd.extend(['-t', str(test_file_path)])
+        cmd.extend(['-J', f"threads={str(threads)}"])
+        cmd.extend(['-J', f"duration={str(duration)}"])
 
         # Log the full command for debugging
         logger.debug(f"Executing command: {' '.join(cmd)}")

--- a/multi_tool_agent/tests/unit/test_tools.py
+++ b/multi_tool_agent/tests/unit/test_tools.py
@@ -20,6 +20,11 @@ class TestJMeterUtils(IsolatedAsyncioTestCase):
         with patch('multi_tool_agent.jmeter_utils.run_jmeter', return_value="Test completed successfully") as mock_run:
             result = await run_jmeter(self.test_jmx)
             self.assertIn("end of run", result.lower())
+    async def test_run_jmeter(self):
+        """Test running a JMeter test with arguments"""
+        with patch('multi_tool_agent.jmeter_utils.run_jmeter', return_value="Test completed successfully") as mock_run:
+            result = await run_jmeter(self.test_jmx, 60, 20)
+            self.assertIn("end of run", result.lower())
             
     @patch('pathlib.Path.exists')
     @patch('pathlib.Path.resolve')


### PR DESCRIPTION
Hi Naveen,

Have added the “-J” flag in the Non-GUI command to pass the property function variables (threads and duration).

1. The property variable name should always be “threads” and “duration” (Hardcoded in command) if user uses property method in the script. (This can be informed to the user from help/about response)
2. If the user wish to run with the threads and duration defined in the script, The command line will always take priority (This applies to K6 as well)

Please let me know your thoughts on this.


 